### PR TITLE
Fix for delete icons not aligning with new character fab

### DIFF
--- a/ttrpg/src/app/components/elements/buttons/delete-character-button/delete-character-button.component.html
+++ b/ttrpg/src/app/components/elements/buttons/delete-character-button/delete-character-button.component.html
@@ -1,9 +1,9 @@
-<button class="red" mat-icon-button *ngIf="!confirmDeletion" (click)="onDeletionButtonsClick($event, 'delete')">
+<button class="red mdc-icon-button--reduced-size" mat-icon-button *ngIf="!confirmDeletion" (click)="onDeletionButtonsClick($event, 'delete')">
 	<mat-icon fontIcon="delete"></mat-icon>
 </button>
-<button class="green"  mat-icon-button *ngIf="confirmDeletion" (click)="onDeletionButtonsClick($event, 'confirm')">
+<button class="green mdc-icon-button--reduced-size" mat-icon-button *ngIf="confirmDeletion" (click)="onDeletionButtonsClick($event, 'confirm')">
 	<mat-icon fontIcon="check"></mat-icon>
 </button>
-<button class="red" mat-icon-button *ngIf="confirmDeletion" (click)="onDeletionButtonsClick($event, 'cancel')">
+<button class="red mdc-icon-button--reduced-size" mat-icon-button *ngIf="confirmDeletion" (click)="onDeletionButtonsClick($event, 'cancel')">
 	<mat-icon fontIcon="close"></mat-icon>
 </button>

--- a/ttrpg/src/app/components/main/startscreen/startscreen.component.html
+++ b/ttrpg/src/app/components/main/startscreen/startscreen.component.html
@@ -4,11 +4,9 @@
 	<mat-action-list class="characterSelectionList">
 		<div mat-subheader class="center-items-vertically space-between">
 			<h2>Deine Charaktere</h2>
-			<div class="miniFabPadding">
-				<button mat-mini-fab color="primary" routerLink="../profile/0">
-					<mat-icon fontIcon="add"></mat-icon>
-				</button>
-			</div>
+			<button class="newCharacterFab" mat-mini-fab color="primary" routerLink="../profile/0">
+				<mat-icon fontIcon="add"></mat-icon>
+			</button>
 		</div>
 		<mat-divider></mat-divider>
 

--- a/ttrpg/src/app/components/main/startscreen/startscreen.component.html
+++ b/ttrpg/src/app/components/main/startscreen/startscreen.component.html
@@ -4,9 +4,11 @@
 	<mat-action-list class="characterSelectionList">
 		<div mat-subheader class="center-items-vertically space-between">
 			<h2>Deine Charaktere</h2>
-			<button mat-mini-fab color="primary" routerLink="../profile/0">
-				<mat-icon fontIcon="add"></mat-icon>
-			</button>
+			<div class="miniFabPadding">
+				<button mat-mini-fab color="primary" routerLink="../profile/0">
+					<mat-icon fontIcon="add"></mat-icon>
+				</button>
+			</div>
 		</div>
 		<mat-divider></mat-divider>
 

--- a/ttrpg/src/app/components/main/startscreen/startscreen.component.sass
+++ b/ttrpg/src/app/components/main/startscreen/startscreen.component.sass
@@ -6,3 +6,6 @@
 .listElements
 	max-height: calc( 100vh - 16rem )
 	overflow: auto
+
+.miniFabPadding
+	padding: 4px

--- a/ttrpg/src/app/components/main/startscreen/startscreen.component.sass
+++ b/ttrpg/src/app/components/main/startscreen/startscreen.component.sass
@@ -7,5 +7,5 @@
 	max-height: calc( 100vh - 16rem )
 	overflow: auto
 
-.miniFabPadding
-	padding: 4px
+.newCharacterFab
+	margin: 4px


### PR DESCRIPTION
Solves Issue #3 

Made the deletion icon buttons a little bit smaller -> 40x40px
They are now the same size as the new character fab.

The alignment Issue was harder to find than anticipated.

### The Problem
![image](https://github.com/GragonGit/Gragons-TTRPG-Tool/assets/46909538/5b5d2880-b55c-43dd-a945-48f68d286162)
The delete icon button itself is 40x40px but the element that surrounds it is actually 48x48px.

The add new character fab is also 40x40 but does not have a surrounding parent that is 48x48px.

Hence the buttons weren't aligned right, as the fab didn't have the empty space around.

I fixed this issue with a parent div with a padding of 4px surrounding the fab.